### PR TITLE
Fix failing unit test

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -20,10 +20,10 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('tests');
   });
 
-  it('should render title', () => {
+  it('should render router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, tests');
+    expect(compiled.querySelector('router-outlet')).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- adjust AppComponent test to look for router outlet instead of static title

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdf0aa5348330954d9ecb79573d42